### PR TITLE
Add pagination controls test for account orders page

### DIFF
--- a/src/page-objects/account-orders-page.ts
+++ b/src/page-objects/account-orders-page.ts
@@ -1,0 +1,24 @@
+import { Page } from '@playwright/test';
+import { BasePage } from './base-page';
+
+export class AccountOrdersPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async isPaginationVisible(): Promise<boolean> {
+    return this.isElementVisible('[data-test="pagination-controls"]');
+  }
+
+  async navigateToNextPage(): Promise<void> {
+    await this.clickElement('[data-test="next-page-button"]');
+  }
+
+  async navigateToPreviousPage(): Promise<void> {
+    await this.clickElement('[data-test="previous-page-button"]');
+  }
+
+  async getCurrentPageNumber(): Promise<string> {
+    return this.getText('[data-test="current-page-number"]');
+  }
+}

--- a/tests/e2e/account-orders.spec.ts
+++ b/tests/e2e/account-orders.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '../../../src/fixtures/test-fixtures';
+import { AccountOrdersPage } from '../../../src/page-objects/account-orders-page';
+import { logInfo } from '../../../src/utils/logger';
+
+test.describe('Account Orders Pagination', () => {
+  let accountOrdersPage: AccountOrdersPage;
+
+  test.beforeEach(async ({ page }) => {
+    accountOrdersPage = new AccountOrdersPage(page);
+    await accountOrdersPage.goto('/account/orders');
+  });
+
+  test('should display pagination controls for users with more than 10 orders', async () => {
+    logInfo('Starting test to verify pagination controls');
+
+    // Verify pagination controls are visible
+    const isPaginationVisible = await accountOrdersPage.isPaginationVisible();
+    expect(isPaginationVisible).toBe(true);
+
+    // Navigate to next page and verify
+    await accountOrdersPage.navigateToNextPage();
+    const currentPageNumber = await accountOrdersPage.getCurrentPageNumber();
+    expect(currentPageNumber).toBe('2');
+
+    // Navigate back to previous page and verify
+    await accountOrdersPage.navigateToPreviousPage();
+    const previousPageNumber = await accountOrdersPage.getCurrentPageNumber();
+    expect(previousPageNumber).toBe('1');
+  });
+});


### PR DESCRIPTION
This PR adds a test for verifying pagination controls in the account orders page for users with more than 10 orders.