### PR TITLE
Add security test for accessing /account/orders without authentication

### DIFF
--- a/src/page-objects/account-page.ts
+++ b/src/page-objects/account-page.ts
@@ -1,0 +1,16 @@
+import { Page } from '@playwright/test';
+import { BasePage } from './base-page';
+
+export class AccountPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async navigateToOrders() {
+    await this.goto('/account/orders');
+  }
+
+  async isLoginPage() {
+    return this.getTitle().then(title => title.includes('Login'));
+  }
+}

--- a/tests/e2e/security/account-orders.spec.ts
+++ b/tests/e2e/security/account-orders.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '../../../src/fixtures/test-fixtures';
+import { AccountPage } from '../../../src/page-objects/account-page';
+
+test.describe('Account Orders Security', () => {
+  test('should redirect to login page when accessing /account/orders without authentication', async ({ page }) => {
+    const accountPage = new AccountPage(page);
+    await accountPage.navigateToOrders();
+    
+    // Verify redirection to login page
+    const isLoginPage = await accountPage.isLoginPage();
+    expect(isLoginPage).toBeTruthy();
+  });
+});


### PR DESCRIPTION
This PR adds a security test to verify that users are redirected to the login page when attempting to access the `/account/orders` route without authentication.