### PR TITLE
XPANBFLFA-57: Add test automation for Order Cancellation confirmation dialog

### DIFF
--- a/src/page-objects/orders-page.ts
+++ b/src/page-objects/orders-page.ts
@@ -1,0 +1,116 @@
+import { Page, Locator } from '@playwright/test';
+import { BasePage } from './base-page';
+import { logStep } from '../utils/logger';
+
+export class OrdersPage extends BasePage {
+  // Locators
+  readonly ordersListLocator: Locator;
+  readonly orderItemLocator: (orderId: string) => Locator;
+  readonly orderStatusLocator: (orderId: string) => Locator;
+  readonly cancelOrderButtonLocator: Locator;
+  readonly confirmCancelButtonLocator: Locator;
+  readonly keepOrderButtonLocator: Locator;
+  readonly confirmationDialogLocator: Locator;
+  readonly loadingIndicatorLocator: Locator;
+  readonly successMessageLocator: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.ordersListLocator = page.locator('.orders-list');
+    this.orderItemLocator = (orderId: string) => page.locator(`.order-item[data-order-id="${orderId}"]`);
+    this.orderStatusLocator = (orderId: string) => this.orderItemLocator(orderId).locator('.order-status');
+    this.cancelOrderButtonLocator = page.locator('button.cancel-order-btn');
+    this.confirmCancelButtonLocator = page.locator('button.confirm-cancel-btn');
+    this.keepOrderButtonLocator = page.locator('button.keep-order-btn');
+    this.confirmationDialogLocator = page.locator('.confirmation-dialog');
+    this.loadingIndicatorLocator = page.locator('.loading-indicator');
+    this.successMessageLocator = page.locator('.success-message');
+  }
+
+  /**
+   * Navigate to the orders page
+   */
+  async goToOrdersPage() {
+    logStep('Navigating to Orders page');
+    await this.goto('/orders');
+  }
+
+  /**
+   * Navigate to a specific order's details
+   */
+  async goToOrderDetails(orderId: string) {
+    logStep(`Navigating to Order Details for ${orderId}`);
+    await this.click(this.orderItemLocator(orderId));
+  }
+
+  /**
+   * Get the status of a specific order
+   */
+  async getOrderStatus(orderId: string): Promise<string | null> {
+    logStep(`Getting status for order ${orderId}`);
+    return await this.getText(this.orderStatusLocator(orderId));
+  }
+
+  /**
+   * Click the cancel order button
+   */
+  async clickCancelOrderButton() {
+    logStep('Clicking Cancel Order button');
+    await this.click(this.cancelOrderButtonLocator);
+  }
+
+  /**
+   * Check if confirmation dialog is displayed
+   */
+  async isConfirmationDialogDisplayed(): Promise<boolean> {
+    logStep('Checking if confirmation dialog is displayed');
+    return await this.isVisible(this.confirmationDialogLocator);
+  }
+
+  /**
+   * Click the "Keep Order" button on the confirmation dialog
+   */
+  async clickKeepOrderButton() {
+    logStep('Clicking Keep Order button on confirmation dialog');
+    await this.click(this.keepOrderButtonLocator);
+  }
+
+  /**
+   * Click the "Cancel Order" button on the confirmation dialog
+   */
+  async clickConfirmCancelButton() {
+    logStep('Clicking Confirm Cancel button on confirmation dialog');
+    await this.click(this.confirmCancelButtonLocator);
+  }
+
+  /**
+   * Check if loading indicator is displayed
+   */
+  async isLoadingIndicatorDisplayed(): Promise<boolean> {
+    logStep('Checking if loading indicator is displayed');
+    return await this.isVisible(this.loadingIndicatorLocator);
+  }
+
+  /**
+   * Check if success message is displayed
+   */
+  async isSuccessMessageDisplayed(): Promise<boolean> {
+    logStep('Checking if success message is displayed');
+    return await this.isVisible(this.successMessageLocator);
+  }
+
+  /**
+   * Wait for order status to change
+   */
+  async waitForOrderStatusChange(orderId: string, expectedStatus: string, timeout: number = 5000): Promise<void> {
+    logStep(`Waiting for order ${orderId} status to change to ${expectedStatus}`);
+    await this.page.waitForFunction(
+      ({ orderId, expectedStatus }) => {
+        const statusElement = document.querySelector(`.order-item[data-order-id="${orderId}"] .order-status`);
+        return statusElement && statusElement.textContent?.trim() === expectedStatus;
+      },
+      { orderId, expectedStatus },
+      { timeout }
+    );
+  }
+}

--- a/tests/e2e/orderCancellation.spec.ts
+++ b/tests/e2e/orderCancellation.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '../../src/fixtures/test-fixtures';
+import { OrdersPage } from '../../src/page-objects/orders-page';
+import { logInfo } from '../../src/utils/logger';
+
+test.describe('Order Cancellation Functionality', () => {
+  let ordersPage: OrdersPage;
+  const testOrderId = 'ORD-12345'; // Test data from XPANBFLFA-57
+
+  test.beforeEach(async ({ page }) => {
+    // Initialize page objects
+    ordersPage = new OrdersPage(page);
+    
+    // Login and navigate to orders page
+    // Note: In a real implementation, you would use a proper login method
+    // This is a placeholder assuming authentication is handled elsewhere
+    await page.goto('/login');
+    await page.fill('input[name="username"]', 'validuser');
+    await page.fill('input[name="password"]', 'validpassword');
+    await page.click('button[type="submit"]');
+    
+    // Navigate to Orders page
+    await ordersPage.goToOrdersPage();
+  });
+
+  /**
+   * @XPANBFLFA-57
+   * Test case: Order Cancellation - Confirmation Dialog Prevents Accidental Cancellations
+   * Verify that the system displays a confirmation dialog when a user attempts to cancel an order,
+   * preventing accidental cancellations and only proceeding with cancellation when explicitly confirmed.
+   */
+  test('should prevent accidental order cancellation with confirmation dialog', async () => {
+    logInfo('Starting test for order cancellation confirmation dialog');
+
+    // Navigate to specific order details
+    await ordersPage.goToOrderDetails(testOrderId);
+
+    // Verify order is in Pending status
+    const initialStatus = await ordersPage.getOrderStatus(testOrderId);
+    expect(initialStatus).toBe('Pending');
+
+    // Click Cancel Order button
+    await ordersPage.clickCancelOrderButton();
+
+    // Verify confirmation dialog is displayed
+    const isDialogDisplayed = await ordersPage.isConfirmationDialogDisplayed();
+    expect(isDialogDisplayed).toBe(true);
+
+    // Click "Keep Order" button to dismiss dialog
+    await ordersPage.clickKeepOrderButton();
+
+    // Verify dialog is closed and order status remains unchanged
+    const isDialogStillDisplayed = await ordersPage.isConfirmationDialogDisplayed();
+    expect(isDialogStillDisplayed).toBe(false);
+    
+    const statusAfterKeeping = await ordersPage.getOrderStatus(testOrderId);
+    expect(statusAfterKeeping).toBe('Pending');
+
+    // Click Cancel Order button again
+    await ordersPage.clickCancelOrderButton();
+
+    // Verify confirmation dialog is displayed again
+    const isDialogDisplayedAgain = await ordersPage.isConfirmationDialogDisplayed();
+    expect(isDialogDisplayedAgain).toBe(true);
+
+    // Click "Cancel Order" button on confirmation dialog to proceed with cancellation
+    await ordersPage.clickConfirmCancelButton();
+
+    // Verify loading indicator appears
+    const isLoadingDisplayed = await ordersPage.isLoadingIndicatorDisplayed();
+    expect(isLoadingDisplayed).toBe(true);
+
+    // Wait for order status to change to "Cancelled"
+    await ordersPage.waitForOrderStatusChange(testOrderId, 'Cancelled');
+
+    // Verify success message is displayed
+    const isSuccessMessageDisplayed = await ordersPage.isSuccessMessageDisplayed();
+    expect(isSuccessMessageDisplayed).toBe(true);
+
+    // Verify final order status
+    const finalStatus = await ordersPage.getOrderStatus(testOrderId);
+    expect(finalStatus).toBe('Cancelled');
+  });
+});


### PR DESCRIPTION
## Description
This PR adds automated test implementation for XPANBFLFA-57 "Order Cancellation - Confirmation Dialog Prevents Accidental Cancellations".

## Changes
- Created OrdersPage page object with methods for order cancellation flow
- Implemented test case for verifying the confirmation dialog prevents accidental cancellations
- Test follows the steps outlined in the test case XPANBFLFA-57

## Testing
The test verifies that:
- Confirmation dialog appears when user attempts to cancel an order
- Clicking "Keep Order" dismisses the dialog without cancelling the order
- Clicking "Cancel Order" on the confirmation dialog proceeds with cancellation
- Order status is updated to "Cancelled" after successful cancellation

## Relates to
Closes XPANBFLFA-57