### PR TITLE
XPANBFLFA-61: Guest user triggers login modal when tapping Buy Now without authentication

### DIFF
--- a/src/page-objects/login-modal-page.ts
+++ b/src/page-objects/login-modal-page.ts
@@ -1,0 +1,136 @@
+import { Page } from '@playwright/test';
+import { BasePage } from './base-page';
+import { logStep } from '../utils/logger';
+
+/**
+ * LoginModalPage - Page Object for the Login/Sign-up Modal
+ * Triggered when a guest user attempts to check out without authentication.
+ */
+export class LoginModalPage extends BasePage {
+  // Modal container
+  private readonly modal = '[data-test="login-modal"]';
+
+  // Modal heading
+  private readonly modalHeading = '[data-test="login-modal-heading"]';
+
+  // Sign-in form fields
+  private readonly usernameInput = '[data-test="login-modal-username"]';
+  private readonly passwordInput = '[data-test="login-modal-password"]';
+
+  // Action buttons
+  private readonly signInButton = '[data-test="login-modal-sign-in-button"]';
+  private readonly signUpButton = '[data-test="login-modal-sign-up-button"]';
+  private readonly closeButton = '[data-test="login-modal-close-button"]';
+
+  // Modal backdrop
+  private readonly backdrop = '[data-test="login-modal-backdrop"]';
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Check if the login modal is visible
+   */
+  async isModalVisible(): Promise<boolean> {
+    logStep('Checking if login modal is visible');
+    return this.isVisible(this.modal);
+  }
+
+  /**
+   * Get the modal heading text
+   */
+  async getModalHeading(): Promise<string | null> {
+    logStep('Getting login modal heading text');
+    return this.getText(this.modalHeading);
+  }
+
+  /**
+   * Check if Sign In button is visible within the modal
+   */
+  async isSignInButtonVisible(): Promise<boolean> {
+    logStep('Checking if Sign In button is visible');
+    return this.isVisible(this.signInButton);
+  }
+
+  /**
+   * Check if Sign Up button/link is visible within the modal
+   */
+  async isSignUpButtonVisible(): Promise<boolean> {
+    logStep('Checking if Sign Up button/link is visible');
+    return this.isVisible(this.signUpButton);
+  }
+
+  /**
+   * Check if Close button is visible within the modal
+   */
+  async isCloseButtonVisible(): Promise<boolean> {
+    logStep('Checking if Close button is visible');
+    return this.isVisible(this.closeButton);
+  }
+
+  /**
+   * Check if username input field is visible
+   */
+  async isUsernameInputVisible(): Promise<boolean> {
+    logStep('Checking if username input is visible');
+    return this.isVisible(this.usernameInput);
+  }
+
+  /**
+   * Check if password input field is visible
+   */
+  async isPasswordInputVisible(): Promise<boolean> {
+    logStep('Checking if password input is visible');
+    return this.isVisible(this.passwordInput);
+  }
+
+  /**
+   * Check if the backdrop (overlay) is visible behind the modal
+   */
+  async isBackdropVisible(): Promise<boolean> {
+    logStep('Checking if modal backdrop is visible');
+    return this.isVisible(this.backdrop);
+  }
+
+  /**
+   * Dismiss the modal by clicking the close button
+   */
+  async closeModal(): Promise<void> {
+    logStep('Closing login modal via close button');
+    await this.click(this.closeButton);
+  }
+
+  /**
+   * Wait for the modal to be visible
+   */
+  async waitForModal(): Promise<void> {
+    logStep('Waiting for login modal to appear');
+    await this.waitForElement(this.modal);
+  }
+
+  /**
+   * Fill in sign-in credentials
+   */
+  async fillSignInCredentials(username: string, password: string): Promise<void> {
+    logStep(`Filling sign-in credentials for user: ${username}`);
+    await this.fill(this.usernameInput, username);
+    await this.fill(this.passwordInput, password);
+  }
+
+  /**
+   * Submit the sign-in form
+   */
+  async submitSignIn(): Promise<void> {
+    logStep('Submitting sign-in form');
+    await this.click(this.signInButton);
+  }
+
+  /**
+   * Click the Sign Up option to switch to sign-up flow
+   */
+  async clickSignUp(): Promise<void> {
+    logStep('Clicking Sign Up option in the modal');
+    await this.click(this.signUpButton);
+  }
+}

--- a/src/page-objects/product-page.ts
+++ b/src/page-objects/product-page.ts
@@ -1,16 +1,54 @@
 import { Page } from '@playwright/test';
 import { BasePage } from './base-page';
+import { logStep } from '../utils/logger';
 
 export class ProductPage extends BasePage {
+  // Product page elements
+  private readonly buyNowButton = '[data-test="buy-now-button"]';
+  private readonly addToCartButton = '[data-test="add-to-cart-button"]';
+  private readonly cartCount = '[data-test="cart-count"]';
+  private readonly userProfileIndicator = '[data-test="user-profile"]';
+
   constructor(page: Page) {
     super(page);
   }
 
+  /**
+   * Click the "Add to Cart" button
+   */
   async addToCart(): Promise<void> {
-    await this.click('[data-test="add-to-cart-button"]');
+    logStep('Clicking Add to Cart button');
+    await this.click(this.addToCartButton);
   }
 
+  /**
+   * Get the current cart item count displayed on the product page
+   */
   async getCartCount(): Promise<string> {
-    return this.getText('[data-test="cart-count"]');
+    return this.getText(this.cartCount);
+  }
+
+  /**
+   * Click the "Buy Now" button to initiate checkout
+   */
+  async clickBuyNow(): Promise<void> {
+    logStep('Clicking Buy Now button');
+    await this.click(this.buyNowButton);
+  }
+
+  /**
+   * Check if the "Buy Now" button is visible on the product page
+   */
+  async isBuyNowButtonVisible(): Promise<boolean> {
+    logStep('Checking if Buy Now button is visible');
+    return this.isVisible(this.buyNowButton);
+  }
+
+  /**
+   * Check if a user profile indicator is visible (i.e., user is authenticated)
+   */
+  async isUserAuthenticated(): Promise<boolean> {
+    logStep('Checking if user is authenticated via profile indicator');
+    return this.isVisible(this.userProfileIndicator);
   }
 }

--- a/tests/e2e/checkout/guestUserLoginModal.spec.ts
+++ b/tests/e2e/checkout/guestUserLoginModal.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '../../../src/fixtures/test-fixtures';
+import { ProductPage } from '../../../src/page-objects/product-page';
+import { LoginModalPage } from '../../../src/page-objects/login-modal-page';
+import { logInfo } from '../../../src/utils/logger';
+
+/**
+ * Test Suite: Guest User Login Modal at Checkout
+ *
+ * Jira Story:    XPANBFLFA-60 – Guest User Redirect to Login at Checkout
+ * Jira Test:     XPANBFLFA-61 – Guest user triggers login modal when tapping "Buy Now" without authentication
+ * Test Condition: TC-1 – Guest user taps "Buy Now" and login modal appears
+ *
+ * Objective:
+ * Verify that the system correctly detects a guest user's unauthenticated state
+ * when they attempt to check out, intercepts the checkout action, and displays a
+ * login/sign-up modal with appropriate options, ensuring that unauthenticated
+ * users cannot proceed to checkout without authentication.
+ */
+test.describe('Guest User Checkout - Login Modal', () => {
+  let productPage: ProductPage;
+  let loginModalPage: LoginModalPage;
+
+  test.beforeEach(async ({ page }) => {
+    productPage = new ProductPage(page);
+    loginModalPage = new LoginModalPage(page);
+
+    // Navigate to a product page as a guest (no authentication)
+    // Storage is clear by default in a new Playwright browser context
+    await productPage.goto('/products/PROD-12345');
+  });
+
+  // XPANBFLFA-61
+  test('should display login modal when guest user taps Buy Now', async ({ page }) => {
+    logInfo('XPANBFLFA-61: Starting test – Guest user triggers login modal on Buy Now');
+
+    // Step 1: Verify user is a guest (no profile indicator visible)
+    const isAuthenticated = await productPage.isUserAuthenticated();
+    expect(isAuthenticated, 'User should not be authenticated before test starts').toBeFalsy();
+
+    // Step 2: Verify product page has loaded and "Buy Now" button is present
+    const isBuyNowVisible = await productPage.isBuyNowButtonVisible();
+    expect(isBuyNowVisible, '"Buy Now" button should be visible on the product page').toBeTruthy();
+
+    // Step 3: Tap "Buy Now" as a guest user
+    await productPage.clickBuyNow();
+
+    // Step 4: Wait for the login modal to appear
+    await loginModalPage.waitForModal();
+
+    // Step 5: Verify the login modal is displayed
+    const isModalVisible = await loginModalPage.isModalVisible();
+    expect(isModalVisible, 'Login modal should be visible after guest user taps "Buy Now"').toBeTruthy();
+
+    // Step 6: Verify modal heading is present and meaningful
+    const modalHeading = await loginModalPage.getModalHeading();
+    expect(modalHeading, 'Modal heading should not be empty').toBeTruthy();
+
+    // Step 7: Verify Sign In option is available in the modal
+    const isSignInVisible = await loginModalPage.isSignInButtonVisible();
+    expect(isSignInVisible, '"Sign In" button should be visible in the login modal').toBeTruthy();
+
+    // Step 8: Verify Sign Up option is available in the modal
+    const isSignUpVisible = await loginModalPage.isSignUpButtonVisible();
+    expect(isSignUpVisible, '"Sign Up" option should be visible in the login modal').toBeTruthy();
+
+    // Step 9: Verify credential input fields are present
+    const isUsernameInputVisible = await loginModalPage.isUsernameInputVisible();
+    expect(isUsernameInputVisible, 'Username input should be visible in the login modal').toBeTruthy();
+
+    const isPasswordInputVisible = await loginModalPage.isPasswordInputVisible();
+    expect(isPasswordInputVisible, 'Password input should be visible in the login modal').toBeTruthy();
+
+    // Step 10: Verify the modal backdrop is displayed (background is overlaid)
+    const isBackdropVisible = await loginModalPage.isBackdropVisible();
+    expect(isBackdropVisible, 'Modal backdrop should be visible to prevent background interaction').toBeTruthy();
+
+    // Step 11: Verify user has NOT been navigated to the checkout page
+    const currentUrl = page.url();
+    expect(currentUrl, 'User should NOT be redirected to checkout without authentication')
+      .not.toContain('/checkout');
+
+    logInfo('XPANBFLFA-61: Test passed – Login modal correctly displayed for guest user on Buy Now');
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements the automated test for **XPANBFLFA-61** – *Guest user triggers login modal when tapping "Buy Now" without authentication*.

**Jira Story:** [XPANBFLFA-60 – Guest User Redirect to Login at Checkout](https://jiraeu.epam.com/browse/XPANBFLFA-60)  
**Jira Test Case:** [XPANBFLFA-61](https://jiraeu.epam.com/browse/XPANBFLFA-61)  
**Test Condition:** TC-1 – Guest user taps "Buy Now" and login modal appears

---

## Changes

### New Files
- `src/page-objects/login-modal-page.ts` — New Page Object for the Login/Sign-up Modal component, covering modal visibility, heading, input fields, action buttons, backdrop, and modal interactions.
- `tests/e2e/checkout/guestUserLoginModal.spec.ts` — New E2E test spec covering TC-1: guest user taps "Buy Now" and login modal is displayed with correct elements.

### Modified Files
- `src/page-objects/product-page.ts` — Extended with `clickBuyNow()`, `isBuyNowButtonVisible()`, and `isUserAuthenticated()` methods to support guest checkout test scenarios.

---

## Test Coverage

| Step | Assertion |
|------|-----------|
| Guest state verified | User profile indicator not visible |
| Buy Now button present | Button visible on product page |
| Modal appears after tap | Login modal is visible |
| Modal heading present | Heading text is not empty |
| Sign In option available | Sign In button visible in modal |
| Sign Up option available | Sign Up button/link visible in modal |
| Credential fields present | Username and password inputs visible |
| Backdrop displayed | Modal overlay visible |
| No checkout navigation | URL does not contain `/checkout` |

---

## How to Run

```bash
npx playwright test tests/e2e/checkout/guestUserLoginModal.spec.ts
```